### PR TITLE
tests/test-no-malloc.c: ∆ sbrk(0) = 0 B

### DIFF
--- a/include/libxalloc.h
+++ b/include/libxalloc.h
@@ -7,6 +7,7 @@
  * @brief Alloctes specified size
  * @param size Size of allocation
  * @return void* Pointer to new allocation
+ * @return NULL If size is zero
  */
 void *xmalloc(size_t size);
 
@@ -15,6 +16,7 @@ void *xmalloc(size_t size);
  * @param count Count of allocations
  * @param size Size of 1 allocation
  * @return void* Pointer to new allocation
+ * @return NULL If count or size is zero
  */
 void *xcalloc(size_t count, size_t size);
 
@@ -24,6 +26,7 @@ void *xcalloc(size_t count, size_t size);
  * @param ptr Pointer to allocated bloc or NULL
  * @param size Size of re-allocation
  * @return void* Pointer to new re-allocation
+ * @return NULL If size is zero
  */
 void *xrealloc(void *ptr, size_t size);
 

--- a/include/xalloc.h
+++ b/include/xalloc.h
@@ -36,7 +36,7 @@ ptr_t xrealloc(ptr_t ptr, size_t size);
  */
 size_t xfree(ptr_t ptr);
 
-#define INIT_ALLOCATION (33 * PAGE_SIZE)
+#define INIT_ALLOCATION (19 * PAGE_SIZE)
 #define COPY_THRESHOLD  (PAGE_SIZE)
 #define MBLOC_PADDING   (16)
 

--- a/include/xalloc.h
+++ b/include/xalloc.h
@@ -9,6 +9,7 @@
  * @brief Alloctes specified size
  * @param size Size of allocation
  * @return ptr_t Pointer to new allocation
+ * @return NULL If size is zero
  */
 ptr_t xmalloc(size_t size);
 
@@ -17,6 +18,7 @@ ptr_t xmalloc(size_t size);
  * @param count Count of allocations
  * @param size Size of 1 allocation
  * @return ptr_t Pointer to new allocation
+ * @return NULL If count or size is zero
  */
 ptr_t xcalloc(size_t count, size_t size);
 
@@ -26,6 +28,7 @@ ptr_t xcalloc(size_t count, size_t size);
  * @param ptr Pointer to allocated bloc or NULL
  * @param size Size of re-allocation
  * @return ptr_t Pointer to new re-allocation
+ * @return NULL If size is zero
  */
 ptr_t xrealloc(ptr_t ptr, size_t size);
 
@@ -36,7 +39,7 @@ ptr_t xrealloc(ptr_t ptr, size_t size);
  */
 size_t xfree(ptr_t ptr);
 
-#define INIT_ALLOCATION (19 * PAGE_SIZE)
+#define INIT_ALLOCATION (32 * PAGE_SIZE)
 #define COPY_THRESHOLD  (PAGE_SIZE)
 #define MBLOC_PADDING   (16)
 

--- a/src/xalloc.c
+++ b/src/xalloc.c
@@ -152,7 +152,7 @@ XALLOC_mbloc_t *__xalloc_mbloc_merge(XALLOC_mbloc_t *bloc, size_t req_sz)
 ptr_t xmalloc(size_t size)
 {
     __xalloc_integrity_verify();
-
+    if (!size) return NULL;
     // attempting to recycle old empty bloc
     if (XALLOC_mhead->start) {
         XALLOC_mbloc_t *reusable = XALLOC_mhead->start;
@@ -173,6 +173,7 @@ ptr_t xmalloc(size_t size)
 ptr_t xcalloc(size_t count, size_t size)
 {
     __xalloc_integrity_verify();
+    if (!(count * size)) return NULL;
     ptr_t p = xmalloc(count * size);
     memset(p, 0, count * size);
     return p;
@@ -182,7 +183,7 @@ ptr_t xcalloc(size_t count, size_t size)
 ptr_t xrealloc(ptr_t ptr, size_t size)
 {
     __xalloc_integrity_verify();
-
+    if (!size) return NULL;
     if (!ptr) return xmalloc(size);
     XALLOC_mbloc_t *bloc = __xalloc_mbloc_find(ptr);
     if (bloc->size == size) return ptr;

--- a/tests/README.md
+++ b/tests/README.md
@@ -129,84 +129,85 @@ Dump of `make test-no-malloc-dbg`.
 
 Indened stuff is by the allocator, unintended stuff is by printf.
 ```
-    malloc: ptr = '0x5a33187028', size = 48 B
-    malloc: ptr = '0x555555b080', size = 8 B
-    malloc: ptr = '0x555555b0b0', size = 48 B
-    malloc: ptr = '0x555555b108', size = 1024 B
-brk init = 0x555555b0e0
+    malloc: ptr = '0x555555b640', size = 48 B
+    malloc: ptr = '0x555555bcb0', size = 8 B
+    malloc: ptr = '0x555555c2f8', size = 48 B
+    malloc: ptr = '0x00', size = 0 B
+    malloc: ptr = '0x555555c968', size = 1024 B
+brk init = 0x555557b028
     free: ptr = '0x00', size = 0 B, freed = 0 B
-    malloc: ptr = '0x555555b530', size = 268435456 B
-    malloc: ptr = '0x556555b558', size = 268435456 B
-    malloc: ptr = '0x557555b580', size = 268435456 B
-    malloc: ptr = '0x558555b5a8', size = 268435456 B
+    malloc: ptr = '0x555557b668', size = 268435456 B
+    malloc: ptr = '0x556557b690', size = 268435456 B
+    malloc: ptr = '0x557557b6b8', size = 268435456 B
+    malloc: ptr = '0x558557b6e0', size = 268435456 B
 0: abcdefghijklmnopqrstuvwxyz
     free: ptr = '0x00', size = 0 B, freed = 0 B
-    free: ptr = '0x555555b530', size = 268435456 B, freed = 0 B
-    free: ptr = '0x556555b558', size = 268435456 B, freed = 0 B
-    free: ptr = '0x557555b580', size = 268435456 B, freed = 0 B
-    free: ptr = '0x558555b5a8', size = 268435456 B, freed = 1073741824 B
-    malloc: ptr = '0x555555b530', size = 268435456 B
-    malloc: ptr = '0x556555b558', size = 268435456 B
-    malloc: ptr = '0x557555b580', size = 268435456 B
-    malloc: ptr = '0x558555b5a8', size = 268435456 B
+    free: ptr = '0x555557b668', size = 268435456 B, freed = 0 B
+    free: ptr = '0x556557b690', size = 268435456 B, freed = 0 B
+    free: ptr = '0x557557b6b8', size = 268435456 B, freed = 0 B
+    free: ptr = '0x558557b6e0', size = 268435456 B, freed = 1073741824 B
+    malloc: ptr = '0x555557b668', size = 268435456 B
+    malloc: ptr = '0x556557b690', size = 268435456 B
+    malloc: ptr = '0x557557b6b8', size = 268435456 B
+    malloc: ptr = '0x558557b6e0', size = 268435456 B
 1: abcdefghijklmnopqrstuvwxyz
     free: ptr = '0x00', size = 0 B, freed = 0 B
-    free: ptr = '0x555555b530', size = 268435456 B, freed = 0 B
-    free: ptr = '0x556555b558', size = 268435456 B, freed = 0 B
-    free: ptr = '0x557555b580', size = 268435456 B, freed = 0 B
-    free: ptr = '0x558555b5a8', size = 268435456 B, freed = 1073741824 B
-    malloc: ptr = '0x555555b530', size = 268435456 B
-    malloc: ptr = '0x556555b558', size = 268435456 B
-    malloc: ptr = '0x557555b580', size = 268435456 B
-    malloc: ptr = '0x558555b5a8', size = 268435456 B
+    free: ptr = '0x555557b668', size = 268435456 B, freed = 0 B
+    free: ptr = '0x556557b690', size = 268435456 B, freed = 0 B
+    free: ptr = '0x557557b6b8', size = 268435456 B, freed = 0 B
+    free: ptr = '0x558557b6e0', size = 268435456 B, freed = 1073741824 B
+    malloc: ptr = '0x555557b668', size = 268435456 B
+    malloc: ptr = '0x556557b690', size = 268435456 B
+    malloc: ptr = '0x557557b6b8', size = 268435456 B
+    malloc: ptr = '0x558557b6e0', size = 268435456 B
 2: abcdefghijklmnopqrstuvwxyz
     free: ptr = '0x00', size = 0 B, freed = 0 B
-    free: ptr = '0x555555b530', size = 268435456 B, freed = 0 B
-    free: ptr = '0x556555b558', size = 268435456 B, freed = 0 B
-    free: ptr = '0x557555b580', size = 268435456 B, freed = 0 B
-    free: ptr = '0x558555b5a8', size = 268435456 B, freed = 1073741824 B
-    malloc: ptr = '0x555555b530', size = 268435456 B
-    malloc: ptr = '0x556555b558', size = 268435456 B
-    malloc: ptr = '0x557555b580', size = 268435456 B
-    malloc: ptr = '0x558555b5a8', size = 268435456 B
+    free: ptr = '0x555557b668', size = 268435456 B, freed = 0 B
+    free: ptr = '0x556557b690', size = 268435456 B, freed = 0 B
+    free: ptr = '0x557557b6b8', size = 268435456 B, freed = 0 B
+    free: ptr = '0x558557b6e0', size = 268435456 B, freed = 1073741824 B
+    malloc: ptr = '0x555557b668', size = 268435456 B
+    malloc: ptr = '0x556557b690', size = 268435456 B
+    malloc: ptr = '0x557557b6b8', size = 268435456 B
+    malloc: ptr = '0x558557b6e0', size = 268435456 B
 3: abcdefghijklmnopqrstuvwxyz
     free: ptr = '0x00', size = 0 B, freed = 0 B
-    free: ptr = '0x555555b530', size = 268435456 B, freed = 0 B
-    free: ptr = '0x556555b558', size = 268435456 B, freed = 0 B
-    free: ptr = '0x557555b580', size = 268435456 B, freed = 0 B
-    free: ptr = '0x558555b5a8', size = 268435456 B, freed = 1073741824 B
-    malloc: ptr = '0x555555b530', size = 268435456 B
-    malloc: ptr = '0x556555b558', size = 268435456 B
-    malloc: ptr = '0x557555b580', size = 268435456 B
-    malloc: ptr = '0x558555b5a8', size = 268435456 B
+    free: ptr = '0x555557b668', size = 268435456 B, freed = 0 B
+    free: ptr = '0x556557b690', size = 268435456 B, freed = 0 B
+    free: ptr = '0x557557b6b8', size = 268435456 B, freed = 0 B
+    free: ptr = '0x558557b6e0', size = 268435456 B, freed = 1073741824 B
+    malloc: ptr = '0x555557b668', size = 268435456 B
+    malloc: ptr = '0x556557b690', size = 268435456 B
+    malloc: ptr = '0x557557b6b8', size = 268435456 B
+    malloc: ptr = '0x558557b6e0', size = 268435456 B
 4: abcdefghijklmnopqrstuvwxyz
     free: ptr = '0x00', size = 0 B, freed = 0 B
-    free: ptr = '0x555555b530', size = 268435456 B, freed = 0 B
-    free: ptr = '0x556555b558', size = 268435456 B, freed = 0 B
-    free: ptr = '0x557555b580', size = 268435456 B, freed = 0 B
-    free: ptr = '0x558555b5a8', size = 268435456 B, freed = 1073741824 B
-    malloc: ptr = '0x555555b530', size = 268435456 B
-    malloc: ptr = '0x556555b558', size = 268435456 B
-    malloc: ptr = '0x557555b580', size = 268435456 B
-    malloc: ptr = '0x558555b5a8', size = 268435456 B
+    free: ptr = '0x555557b668', size = 268435456 B, freed = 0 B
+    free: ptr = '0x556557b690', size = 268435456 B, freed = 0 B
+    free: ptr = '0x557557b6b8', size = 268435456 B, freed = 0 B
+    free: ptr = '0x558557b6e0', size = 268435456 B, freed = 1073741824 B
+    malloc: ptr = '0x555557b668', size = 268435456 B
+    malloc: ptr = '0x556557b690', size = 268435456 B
+    malloc: ptr = '0x557557b6b8', size = 268435456 B
+    malloc: ptr = '0x558557b6e0', size = 268435456 B
 5: abcdefghijklmnopqrstuvwxyz
     free: ptr = '0x00', size = 0 B, freed = 0 B
-    free: ptr = '0x555555b530', size = 268435456 B, freed = 0 B
-    free: ptr = '0x556555b558', size = 268435456 B, freed = 0 B
-    free: ptr = '0x557555b580', size = 268435456 B, freed = 0 B
-    free: ptr = '0x558555b5a8', size = 268435456 B, freed = 1073741824 B
-    malloc: ptr = '0x555555b530', size = 268435456 B
-    malloc: ptr = '0x556555b558', size = 268435456 B
-    malloc: ptr = '0x557555b580', size = 268435456 B
-    malloc: ptr = '0x558555b5a8', size = 268435456 B
+    free: ptr = '0x555557b668', size = 268435456 B, freed = 0 B
+    free: ptr = '0x556557b690', size = 268435456 B, freed = 0 B
+    free: ptr = '0x557557b6b8', size = 268435456 B, freed = 0 B
+    free: ptr = '0x558557b6e0', size = 268435456 B, freed = 1073741824 B
+    malloc: ptr = '0x555557b668', size = 268435456 B
+    malloc: ptr = '0x556557b690', size = 268435456 B
+    malloc: ptr = '0x557557b6b8', size = 268435456 B
+    malloc: ptr = '0x558557b6e0', size = 268435456 B
 6: abcdefghijklmnopqrstuvwxyz
     free: ptr = '0x00', size = 0 B, freed = 0 B
-    free: ptr = '0x555555b530', size = 268435456 B, freed = 0 B
-    free: ptr = '0x556555b558', size = 268435456 B, freed = 0 B
-    free: ptr = '0x557555b580', size = 268435456 B, freed = 0 B
-    free: ptr = '0x558555b5a8', size = 268435456 B, freed = 1073741824 B
-brk exit = 0x555555b508
+    free: ptr = '0x555557b668', size = 268435456 B, freed = 0 B
+    free: ptr = '0x556557b690', size = 268435456 B, freed = 0 B
+    free: ptr = '0x557557b6b8', size = 268435456 B, freed = 0 B
+    free: ptr = '0x558557b6e0', size = 268435456 B, freed = 1073741824 B
+brk exit = 0x555557b028
     free: ptr = '0x00', size = 0 B, freed = 0 B
-brk difference = 1064 B
+brk difference = 0 B
     free: ptr = '0x00', size = 0 B, freed = 0 B
 ```

--- a/tests/test-no-malloc.c
+++ b/tests/test-no-malloc.c
@@ -95,6 +95,14 @@ void free(void *ptr)
 
 int main(int argc, char *argv[])
 {
+    /* Because of differences in when malloc is called in different architectures,
+     * this malloc call is meant to explicitly initialize the allocator.
+     * This will result in an intial allocation of some KB, and brk will be shifted.
+     * This is done to get a consistent reading of brk init across all architectures.
+     * NOTE that malloc(0) does nothing except when allocator is not initialized.
+     * In such a case, it'll call the initializer.
+     */
+    malloc(0);
     void *p0 = sbrk(0);
     printf("brk init = %p\n", p0);
     for (int i = 0; i < 7; i++) {
@@ -123,8 +131,5 @@ int main(int argc, char *argv[])
     void *p1 = sbrk(0);
     printf("brk exit = %p\n", p1);
     printf("brk difference = %zu B\n", (size_t) (p1 - p0));
-    // __xalloc_print_str(1, "brk difference = "); 
-    // __xalloc_print_ui64(1, (size_t) (p1 - p0));
-    // __xalloc_print_str(1, " B\n");
     return 0;
 }


### PR DESCRIPTION
- nada
- update doc, modified init alloc size to 128 KB
- x*alloc returns NULL if size = 0 B
- updated tests/README.md
- added a malloc(0) to test-no-malloc
- updated tests/README.md
- updated tests/README.md
